### PR TITLE
Add bbbcccvvv support to VerseRef constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ console.log(verseRef.chapterNum); // 3
 console.log(verseRef.verse); // '4b-5a'
 console.log(verseRef.verseNum); // 4
 
+// construct from a bbbcccvvv number
+verseRef = new VerseRef(42003004);
+console.log(verseRef.bookNum); // 42
+console.log(verseRef.chapterNum); // 3
+console.log(verseRef.verseNum); // 4
+
 // construct from an existing VerseRef
 verseRef = new VerseRef(verseRef);
 console.log(verseRef.book); // 'LUK'

--- a/src/verse-ref.test.ts
+++ b/src/verse-ref.test.ts
@@ -116,7 +116,7 @@ describe('VerseRef', () => {
       expect(vref.allVerses().length).toEqual(2);
       expect(vref.versification).toEqual(ScrVers.Vulgate);
     });
-    /*
+
     it('should construct from BBBCCCVV without versification', () => {
       const vref = new VerseRef(12015013);
       expect(vref.BBBCCCVVV).toEqual(12015013);
@@ -128,7 +128,18 @@ describe('VerseRef', () => {
       expect(vref.verse).toEqual('13');
       expect(vref.versification).toEqual(VerseRef.defaultVersification);
     });
-    */
+
+    it('should construct from BBBCCCVV with versification', () => {
+      const vref = new VerseRef(42003004, ScrVers.Vulgate);
+      expect(vref.BBBCCCVVV).toEqual(42003004);
+      // expect(vref.BBBCCCVVVS).toEqual('042003004');
+      expect(vref.book).toEqual('LUK');
+      expect(vref.bookNum).toEqual(42);
+      expect(vref.chapterNum).toEqual(3);
+      expect(vref.verseNum).toEqual(4);
+      expect(vref.verse).toEqual('4');
+      expect(vref.versification).toEqual(ScrVers.Vulgate);
+    });
   });
 
   describe('Chapter and Verse as Empty Strings', () => {

--- a/src/verse-ref.ts
+++ b/src/verse-ref.ts
@@ -156,7 +156,7 @@ export class VerseRef {
   private _verseNum = 0;
   private _verse?: string;
 
-  constructor(verseStr: string, versification?: ScrVers);
+  constructor(verseStr: string | number, versification?: ScrVers);
   constructor(verseRef: VerseRef);
   constructor(versification?: ScrVers);
   constructor(book: string, chapter: string, verse: string, versification?: ScrVers);
@@ -175,6 +175,16 @@ export class VerseRef {
           chapterEtc != null && chapterEtc instanceof ScrVers ? chapterEtc : undefined;
         this.setEmpty(_versification);
         this.parse(_verserStr);
+      } else if (bookEtc != null && typeof bookEtc === 'number') {
+        // constructor(bbbcccvvv: number, versification?: ScrVers);
+        const _versification: ScrVers | undefined =
+          chapterEtc != null && chapterEtc instanceof ScrVers ? chapterEtc : undefined;
+        this.setEmpty(_versification);
+        this._verseNum = bookEtc % VerseRef.chapterDigitShifter;
+        this._chapterNum = Math.floor(
+          (bookEtc % VerseRef.bookDigitShifter) / VerseRef.chapterDigitShifter
+        );
+        this._bookNum = Math.floor(bookEtc / VerseRef.bookDigitShifter);
       } else if (chapterEtc == null) {
         if (bookEtc != null && bookEtc instanceof VerseRef) {
           // constructor(verseRef: VerseRef);


### PR DESCRIPTION
This PR adds support for bbbcccvvv values to the `VerseRef` constructor, enabling the unit test for this feature, and adding another unit test to test specifying the versification with the bbbcccvvv constructor.