### PR TITLE
fix `VerseRef.chapterNum` setter infinite recursion

### DIFF
--- a/src/verse-ref.test.ts
+++ b/src/verse-ref.test.ts
@@ -1,5 +1,5 @@
 import { ScrVers } from './scr-vers';
-import { SerializedVerseRef, VerseRef } from './verse-ref';
+import { SerializedVerseRef, VerseRef, VerseRefException } from './verse-ref';
 
 describe('VerseRef', () => {
   const RTL_MARKER = '\u200F';
@@ -142,6 +142,58 @@ describe('VerseRef', () => {
     });
   });
 
+  describe('Build VerseRef by Props', () => {
+    it('should build a VerseRef by setting properties', () => {
+      let vref = new VerseRef();
+      vref.versification = ScrVers.English;
+      expect(vref.validStatus).toEqual(VerseRef.ValidStatusType.OutOfRange);
+      expect(vref.BBBCCCVVV).toEqual(0);
+
+      vref.bookNum = 13;
+      // Chapter 0 is out of range in the C#, but `internalValid()` can't detect that until the
+      // versification port lands (see the TODO in `verse-ref.ts`).
+      // expect(vref.validStatus).toEqual(VerseRef.ValidStatusType.OutOfRange);
+      expect(vref.BBBCCCVVV).toEqual(13000000);
+      expect(vref.bookNum).toEqual(13);
+      expect(vref.chapterNum).toEqual(0);
+      expect(vref.verseNum).toEqual(0);
+
+      vref.chapterNum = 1;
+      vref.verseNum = 0;
+      expect(vref.valid).toBe(true);
+      expect(vref.BBBCCCVVV).toEqual(13001000);
+      expect(vref.bookNum).toEqual(13);
+      expect(vref.chapterNum).toEqual(1);
+      expect(vref.verseNum).toEqual(0);
+
+      vref.chapterNum = 14;
+      vref.verseNum = 15;
+      expect(vref.valid).toBe(true);
+      expect(vref.BBBCCCVVV).toEqual(13014015);
+      expect(vref.bookNum).toEqual(13);
+      expect(vref.chapterNum).toEqual(14);
+      expect(vref.verseNum).toEqual(15);
+
+      vref = new VerseRef();
+      vref.versification = ScrVers.English;
+      vref.chapterNum = 16;
+      expect(vref.validStatus).toEqual(VerseRef.ValidStatusType.OutOfRange);
+      expect(vref.BBBCCCVVV).toEqual(16000);
+      expect(vref.bookNum).toEqual(0);
+      expect(vref.chapterNum).toEqual(16);
+      expect(vref.verseNum).toEqual(0);
+
+      vref = new VerseRef();
+      vref.versification = ScrVers.English;
+      vref.verseNum = 17;
+      expect(vref.validStatus).toEqual(VerseRef.ValidStatusType.OutOfRange);
+      expect(vref.BBBCCCVVV).toEqual(17);
+      expect(vref.bookNum).toEqual(0);
+      expect(vref.chapterNum).toEqual(0);
+      expect(vref.verseNum).toEqual(17);
+    });
+  });
+
   describe('Chapter and Verse as Empty Strings', () => {
     it('should handle empty chapter and verse', () => {
       const vref = new VerseRef('LUK', '', '', ScrVers.Septuagint);
@@ -158,6 +210,21 @@ describe('VerseRef', () => {
 
   // Tests that don't exist in the C#.
   describe('Extra (TS-only tests)', () => {
+    describe('Property setters', () => {
+      it('should throw when chapterNum is negative', () => {
+        const vref = new VerseRef('LUK 3:4', ScrVers.English);
+        expect(() => {
+          vref.chapterNum = -1;
+        }).toThrow(VerseRefException);
+      });
+
+      it('should not throw when chapterNum is zero', () => {
+        const vref = new VerseRef('LUK 3:4', ScrVers.English);
+        vref.chapterNum = 0;
+        expect(vref.chapterNum).toEqual(0);
+      });
+    });
+
     describe('String', () => {
       it('should convert to empty string', () => {
         const vref = new VerseRef();

--- a/src/verse-ref.ts
+++ b/src/verse-ref.ts
@@ -340,8 +340,10 @@ export class VerseRef {
     return this._chapterNum;
   }
   set chapterNum(value: number) {
-    // ToDo: replace or remove this placeholder
-    this.chapterNum = value;
+    if (value < 0) {
+      throw new VerseRefException('ChapterNum can not be negative');
+    }
+    this._chapterNum = value;
   }
 
   /**


### PR DESCRIPTION
Fixes the `VerseRef.chapterNum` setter, which recursed infinitely on every assignment. Built test-first: the ported C# test was confirmed failing with `RangeError` before the fix went in.

## The bug

`src/verse-ref.ts` assigned the property to itself instead of the backing field, behind a `ToDo` placeholder:

```ts
set chapterNum(value: number) {
  // ToDo: replace or remove this placeholder
  this.chapterNum = value;
}
```

There's no guard in front of it, so **every** input threw `RangeError: Maximum call stack size exceeded` — `= 5`, `= 0`, `= -1` alike. The property was completely unusable.

Nothing inside the library was affected: the numeric constructor writes `_chapterNum` directly (`verse-ref.ts:244`), and `setEmpty()` and the `chapter` string setter do the same. That line was the only write through the setter, so this was reachable only by external consumers.

## The fix

Ported from the C# [`VerseRef.ChapterNum`](https://github.com/sillsdev/libpalaso/blob/master/SIL.Scripture/VerseRef.cs), which guards negatives then assigns:

```csharp
public int ChapterNum
{
    get { return chapterNum; }
    set
    {
        if (value < 0)
            throw new VerseRefException("ChapterNum can not be negative");
        chapterNum = (short)value;
    }
}
```

giving:

```ts
set chapterNum(value: number) {
  if (value < 0) {
    throw new VerseRefException('ChapterNum can not be negative');
  }
  this._chapterNum = value;
}
```

This mirrors the existing `bookNum` setter, which already ports its C# counterpart's throw verbatim. The `(short)` cast is deliberately not replicated — TS has no `short`, and emulating 16-bit wraparound would be fidelity at the cost of sense.

The `-1` sentinel path is untouched. `setEmpty()` and `set chapter('')` write `_chapterNum` directly, so the new guard never intercepts them — exactly as in the C#, where `Chapter` sets the field to `-1` without going through `ChapterNum`. `Chapter and Verse as Empty Strings` still passes.

## Tests

Ports [`BuildVerseRefByProps`](https://github.com/sillsdev/libpalaso/blob/master/SIL.Scripture.Tests/VerseRefTests.cs) from `SIL.Scripture.Tests`, which builds a `VerseRef` entirely through property setters and so covers this path directly.

**One assertion is commented out.** After `bookNum = 13`, the C# expects `OutOfRange` because chapter 0 is invalid, but `internalValid()` has its chapter/verse range check commented out pending the versification port (see the `TODO` at `verse-ref.ts:623`), so it returns `Valid`. Commented rather than weakened, following the existing convention in this file, and it should be restored when that port lands. The other five `validStatus`/`valid` assertions in the ported test pass legitimately.

Also adds two TS-only tests under `Extra (TS-only tests)` for the negative guard and the zero boundary, since the C# has no direct test for the setter's validation.

## Is this a behaviour change?

Technically yes, but not a breaking one. Since every prior assignment crashed, there is no code path that worked before and behaves differently now — this is a patch-level repair of a property that was 100% unusable. The public API surface is unchanged; the `.d.ts` declarations for `chapterNum` are identical.

The only way to have depended on the old behaviour was catching the stack overflow as control flow, and even that largely survives: negatives still throw, now as `VerseRefException` rather than `RangeError`.

## Verification

- `npm run test:ci` — 43 passed (was 40)
- `npm run lint` — clean
- `npm run prettier:ci` — clean
- `npm run build` — clean

Red was confirmed twice before the fix: first `RangeError` from the recursion for the ported test, then `expected function to throw an error, but it didn't` for the negative guard.

## Follow-up

`set verseNum` is the same class of mis-port and still carries its `ToDo`. The C# is:

```csharp
if (value < 0) throw new VerseRefException("VerseNum can not be negative");
verseNum = (short)value;
verse = null;
```

The TS does a bare `this._verseNum = value` — missing both the guard and the `verse = null`. So `new VerseRef('LUK','3','4b-5a')` then `verseNum = 9` leaves a stale `'4b-5a'` in the `verse` getter. Deliberately left out of this PR: unlike `chapterNum`, that setter works today, so fixing it changes the observable output of working consumer code and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
